### PR TITLE
Remove boundary WKB geometry parsing 

### DIFF
--- a/tutorials/duckdb_tutorial.md
+++ b/tutorials/duckdb_tutorial.md
@@ -114,6 +114,8 @@ table_query = f"""
 """
 duckdb.sql(table_query)
 
+duckdb.sql("SELECT * FROM aus_buildings").show()
+
 ┌──────────────────────┬─────────────────┐
 │        s2_id         │ buildings_count │
 │        int64         │     int64       │


### PR DESCRIPTION
Removes the parsing of WKB geometries when reading the boundary.geojson file, as it is not needed since DuckDB v0.9.2.

Also, adds a missing `duckdb.show()` on the `aus_buildings` table.
 
Closes #2 , relates #1